### PR TITLE
feat(plan): update execution plan to use actions

### DIFF
--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -96,22 +96,14 @@ export function RunExecutionPlan (plan, privKey, progress, client) {
   }
   const nodeClient = client || new NodeClient(plan.host, privKey)
   ExecutionPlan().fromJSON(plan)
-  if (plan.calls.length === 0) {
+  if (plan.actions.length === 0) {
     throw new Error('Execution plan must have at least one call.')
   }
   let p = Promise.resolve()
   const prog = progress || function () {}
-  plan.calls.forEach((call) => {
+  plan.actions.forEach((action) => {
     p = p.then((res) => {
       prog(res)
-      const action = {
-        channelID: plan.channelID,
-        nonce: null,
-        category: {
-          enum: 1,
-          value: call
-        }
-      }
       return TransactionForResult(nodeClient, action)
     })
   })

--- a/test/client/utils.js
+++ b/test/client/utils.js
@@ -66,11 +66,10 @@ describe('RunExecutionPlan', () => {
   it('should not throw with valid plan', () => {
     const plan = {
       host: 'asdf',
-      channelID: '0'.repeat(64),
-      calls: [
-        { function: 'asdf', parameters: [] },
-        { function: 'asdf', parameters: [] },
-        { function: 'asdf', parameters: [] }
+      actions: [
+        { address: x256, channelID: x256, nonce: '0', category: { enum: 1, value: { function: 'asdf', parameters: [] } } },
+        { address: x256, channelID: x256, nonce: '0', category: { enum: 1, value: { function: 'asdf', parameters: [] } } },
+        { address: x256, channelID: x256, nonce: '0', category: { enum: 1, value: { function: 'asdf', parameters: [] } } }
       ]
     }
     expect(() => RunExecutionPlan(plan, 'asdf', function () {}, getMockClient())).to.not.throw()
@@ -79,8 +78,7 @@ describe('RunExecutionPlan', () => {
   it('should throw with empty calls array', () => {
     const plan = {
       host: 'asdf',
-      channelID: '0'.repeat(64),
-      calls: []
+      actions: []
     }
     expect(() => RunExecutionPlan(plan, 'asdf', function () {}, getMockClient())).to.throw()
   })
@@ -99,16 +97,16 @@ describe('RunExecutionPlan', () => {
     const callbackFake = sinon.fake()
     const plan = {
       host: 'asdf',
-      channelID: '0'.repeat(64),
-      calls: [
-        { function: 'one', parameters: [ 'AAAAA29uZQA=', 'AAAAA3R3bwA=' ] },
-        { function: 'two', parameters: [] },
-        { function: 'three', parameters: [] }
+      actions: [
+        { address: x256, channelID: x256, nonce: '3', category: { enum: 1, value: { function: 'one', parameters: [ 'AAAAA29uZQA=', 'AAAAA3R3bwA=' ] } } },
+        { address: x256, channelID: x256, nonce: '3', category: { enum: 1, value: { function: 'two', parameters: [] } } },
+        { address: x256, channelID: x256, nonce: '3', category: { enum: 1, value: { function: 'three', parameters: [] } } }
       ]
     }
     return RunExecutionPlan(plan, 'asdf', function () { callbackFake() }, client).then(res => {
       expect(client.transactionSubmit.calledWith({
-        channelID: '0'.repeat(64),
+        channelID: x256,
+        address: x256,
         nonce: '3',
         category: {
           enum: 1,
@@ -119,7 +117,8 @@ describe('RunExecutionPlan', () => {
         }
       })).to.equal(true)
       expect(client.transactionSubmit.calledWith({
-        channelID: '0'.repeat(64),
+        channelID: x256,
+        address: x256,
         nonce: '3',
         category: {
           enum: 1,
@@ -130,7 +129,8 @@ describe('RunExecutionPlan', () => {
         }
       })).to.equal(true)
       expect(client.transactionSubmit.calledWith({
-        channelID: '0'.repeat(64),
+        channelID: x256,
+        address: x256,
         nonce: '3',
         category: {
           enum: 1,


### PR DESCRIPTION
We need the execution plan to be able to execute generic actions so that
we can use an update authorization request to login to xchng.