### PR TITLE
feat(custom-args): adding the ability to use js dicts

### DIFF
--- a/src/client/contract-client.js
+++ b/src/client/contract-client.js
@@ -303,11 +303,11 @@ function pollResult (txID, resolve, reject, nodeClient, resultFormat, xdrTypes, 
 */
 function processObjectArg (arg) {
   // For a 'file' type argument, read the file and return it as parsed JSON.
-  if (arg.type === 'file') {
+  if (arg._type === 'file') {
     const fileContent = fs.readFileSync(arg.value).toString('utf-8')
     return JSON.parse(fileContent)
   }
-  return new Error('Could not process type: ' + JSON.stringify(arg))
+  return arg
 }
 
 export default Client


### PR DESCRIPTION
We previously passed custom types as a string that needed to be parsed
for custom types. This was easier with the CLI but is somewhat clunky in
the browser. We now accept both string and javascript dicts as
arguments. To make this possible I changed the 'file' argument used by
the CLI to be stored at the _type keyword if being used.