### PR TITLE
feat(address): export function that can get address from priv key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,14 @@
 import NodeClient from './client/node-client.js'
 import ContractClient from './client/contract-client.js'
 import { RunExecutionPlan } from './client/utils.js'
-import { generateKeys } from './crypto/ecc-ed25519.js'
+import { fromPrivate, generateKeys } from './crypto/ecc-ed25519.js'
 
 function AccountGenerate () {
   return generateKeys()
 }
 
-export { NodeClient, ContractClient, AccountGenerate, RunExecutionPlan }
+function AddressFromPrivate (priv) {
+  return fromPrivate(priv)
+}
+
+export { NodeClient, ContractClient, AccountGenerate, RunExecutionPlan, AddressFromPrivate }


### PR DESCRIPTION
This is helpful for running execution plans from the web. It can be used to get the address without a user having to type it in (they must use their private key to sign the transaction regardless).