### PR TITLE
fix: custom type returns were erroring on readonly calls

### DIFF
--- a/src/client/contract-client.js
+++ b/src/client/contract-client.js
@@ -195,7 +195,7 @@ class Client {
               return reject(new Error('Readonly status was bad: ' + res.status))
             }
             const resultFormat = abiEntry.outputs[0]
-            const r = getXDRObject(resultFormat)
+            const r = getXDRObject(resultFormat, this.xdrTypes)
             if (r === undefined) {
               return reject(Error('Type not identified: ' + resultFormat))
             }


### PR DESCRIPTION
Simply forgot to pass the xdrTypes to getXDRObject for the readonly
function return handling. Also have added tests for contract client
write/readonly return/args.